### PR TITLE
Update to only show on Zen.

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -14,5 +14,6 @@
         "Anoms12"
     ],
     "createdAt": "2025-05-20",
-    "updatedAt": "2025-05-20"
+    "updatedAt": "2025-05-20",
+    "fork": ["zen"]
 }


### PR DESCRIPTION
@Anoms12 Sine will be adding cross-browser support soon, and as such, I am adding a property to only show mods when they are compatible with the user's browser. That's what this pr does.

*I do want, when you have time, this to work for Floorp. When you do that, just change the fork property to `["zen", "floorp"]` to add floorp to the list.*